### PR TITLE
test: add unit tests for core packages

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldCheckForUpdate(t *testing.T) {
+	// Last check was 25 hours ago — should check
+	c := &Config{LastUpdateCheck: time.Now().Add(-25 * time.Hour)}
+	if !c.ShouldCheckForUpdate() {
+		t.Error("expected true when last check was 25h ago")
+	}
+
+	// Last check was 1 hour ago — should not check
+	c = &Config{LastUpdateCheck: time.Now().Add(-1 * time.Hour)}
+	if c.ShouldCheckForUpdate() {
+		t.Error("expected false when last check was 1h ago")
+	}
+
+	// Never checked (zero value) — should check
+	c = &Config{}
+	if !c.ShouldCheckForUpdate() {
+		t.Error("expected true when never checked")
+	}
+}
+
+func TestIsLocalProvider(t *testing.T) {
+	tests := []struct {
+		provider string
+		expected bool
+	}{
+		{"ollama", true},
+		{"llamacpp", true},
+		{"claude", false},
+		{"openai", false},
+		{"openrouter", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := IsLocalProvider(tt.provider)
+		if got != tt.expected {
+			t.Errorf("IsLocalProvider(%q) = %v, want %v", tt.provider, got, tt.expected)
+		}
+	}
+}
+
+func TestGetEnvVarName(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"api_key", "OCTRAFIC_API_KEY"},
+		{"provider", "OCTRAFIC_PROVIDER"},
+		{"base_url", "OCTRAFIC_BASE_URL"},
+		{"", "OCTRAFIC_"},
+	}
+
+	for _, tt := range tests {
+		got := GetEnvVarName(tt.key)
+		if got != tt.expected {
+			t.Errorf("GetEnvVarName(%q) = %q, want %q", tt.key, got, tt.expected)
+		}
+	}
+}

--- a/internal/core/converter/converter_test.go
+++ b/internal/core/converter/converter_test.go
@@ -1,0 +1,61 @@
+package converter
+
+import "testing"
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain JSON",
+			input:    `{"openapi": "3.0.0"}`,
+			expected: `{"openapi": "3.0.0"}`,
+		},
+		{
+			name:     "markdown code block with json tag",
+			input:    "```json\n{\"key\": \"value\"}\n```",
+			expected: `{"key": "value"}`,
+		},
+		{
+			name:     "markdown code block without tag",
+			input:    "```\n{\"key\": \"value\"}\n```",
+			expected: `{"key": "value"}`,
+		},
+		{
+			name:     "JSON with surrounding text",
+			input:    "Here is the result:\n{\"name\": \"test\"}\nDone.",
+			expected: `{"name": "test"}`,
+		},
+		{
+			name:     "nested JSON",
+			input:    `{"outer": {"inner": "value"}}`,
+			expected: `{"outer": {"inner": "value"}}`,
+		},
+		{
+			name:     "no JSON",
+			input:    "no json here",
+			expected: "",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "unclosed brace",
+			input:    `{"key": "value"`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractJSON(tt.input)
+			if got != tt.expected {
+				t.Errorf("extractJSON() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/core/parser/parser.go
+++ b/internal/core/parser/parser.go
@@ -331,13 +331,13 @@ func parseGraphQL(content string) (*Specification, error) {
 		if strings.HasPrefix(trimmed, "type Query") && (strings.Contains(trimmed, "{") || strings.Contains(trimmed, "implements")) {
 			currentType = "Query"
 			inType = true
-			braceDepth = 0
+			braceDepth = strings.Count(trimmed, "{") - strings.Count(trimmed, "}")
 			continue
 		}
 		if strings.HasPrefix(trimmed, "type Mutation") && (strings.Contains(trimmed, "{") || strings.Contains(trimmed, "implements")) {
 			currentType = "Mutation"
 			inType = true
-			braceDepth = 0
+			braceDepth = strings.Count(trimmed, "{") - strings.Count(trimmed, "}")
 			continue
 		}
 

--- a/internal/core/parser/parser_test.go
+++ b/internal/core/parser/parser_test.go
@@ -1,0 +1,460 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIsHTTPMethod(t *testing.T) {
+	valid := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
+	for _, m := range valid {
+		if !isHTTPMethod(m) {
+			t.Errorf("expected %q to be a valid HTTP method", m)
+		}
+	}
+
+	invalid := []string{"get", "CONNECT", "TRACE", "", "FOO"}
+	for _, m := range invalid {
+		if isHTTPMethod(m) {
+			t.Errorf("expected %q to not be a valid HTTP method", m)
+		}
+	}
+}
+
+func TestIsHTTPMethodLowercase(t *testing.T) {
+	valid := []string{"get", "post", "put", "delete", "patch", "options", "head", "trace"}
+	for _, m := range valid {
+		if !isHTTPMethodLowercase(m) {
+			t.Errorf("expected %q to be valid", m)
+		}
+	}
+
+	invalid := []string{"connect", "", "foo", "parameters", "servers"}
+	for _, m := range invalid {
+		if isHTTPMethodLowercase(m) {
+			t.Errorf("expected %q to not be valid", m)
+		}
+	}
+}
+
+func TestExtractPathFromURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://api.example.com/users/123", "/users/123"},
+		{"http://localhost:8080/api/v1/items", "/api/v1/items"},
+		{"{{base_url}}/users", "/users"},
+		{"/users", "/users"},
+		{"users", "/users"},
+		{"https://api.example.com/", "/"},
+		{"https://api.example.com", "/"},
+	}
+
+	for _, tt := range tests {
+		got := extractPathFromURL(tt.input)
+		if got != tt.expected {
+			t.Errorf("extractPathFromURL(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestExtractTagsFromPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected []string
+	}{
+		{"/users", []string{"users"}},
+		{"/users/{id}", []string{"users"}},
+		{"/users/{id}/orders", []string{"users", "orders"}},
+		{"/api/v1/{id}", []string{"api"}},
+		{"/", []string{}},
+	}
+
+	for _, tt := range tests {
+		got := extractTagsFromPath(tt.path)
+		if len(got) != len(tt.expected) {
+			t.Errorf("extractTagsFromPath(%q) = %v, want %v", tt.path, got, tt.expected)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.expected[i] {
+				t.Errorf("extractTagsFromPath(%q)[%d] = %q, want %q", tt.path, i, got[i], tt.expected[i])
+			}
+		}
+	}
+}
+
+func TestExtractRequestBody(t *testing.T) {
+	input := map[string]any{
+		"content": map[string]any{
+			"application/json": map[string]any{
+				"schema": map[string]any{
+					"properties": map[string]any{
+						"name":  map[string]any{"type": "string"},
+						"email": map[string]any{"type": "string"},
+						"age":   map[string]any{"type": "integer"},
+					},
+				},
+			},
+		},
+	}
+
+	result := extractRequestBody(input)
+	if result["name"] != "string" {
+		t.Errorf("expected name=string, got %v", result["name"])
+	}
+	if result["email"] != "string" {
+		t.Errorf("expected email=string, got %v", result["email"])
+	}
+	if result["age"] != "integer" {
+		t.Errorf("expected age=integer, got %v", result["age"])
+	}
+
+	// Empty input
+	empty := extractRequestBody(map[string]any{})
+	if len(empty) != 0 {
+		t.Errorf("expected empty result, got %v", empty)
+	}
+}
+
+func TestParseMarkdown(t *testing.T) {
+	content := `# API Documentation
+
+## GET /users
+List all users
+
+## POST /users
+Create a new user
+
+### DELETE /users/{id}
+Delete a specific user
+`
+
+	spec, err := parseMarkdown(content)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if spec.Format != "markdown" {
+		t.Errorf("expected format 'markdown', got %q", spec.Format)
+	}
+
+	if len(spec.Endpoints) != 3 {
+		t.Fatalf("expected 3 endpoints, got %d", len(spec.Endpoints))
+	}
+
+	expected := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/users"},
+		{"POST", "/users"},
+		{"DELETE", "/users/{id}"},
+	}
+
+	for i, e := range expected {
+		if spec.Endpoints[i].Method != e.method {
+			t.Errorf("endpoint[%d] method = %q, want %q", i, spec.Endpoints[i].Method, e.method)
+		}
+		if spec.Endpoints[i].Path != e.path {
+			t.Errorf("endpoint[%d] path = %q, want %q", i, spec.Endpoints[i].Path, e.path)
+		}
+	}
+}
+
+func TestParseMarkdownEmpty(t *testing.T) {
+	spec, err := parseMarkdown("")
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+	if len(spec.Endpoints) != 0 {
+		t.Errorf("expected 0 endpoints, got %d", len(spec.Endpoints))
+	}
+}
+
+func TestParseOpenAPI(t *testing.T) {
+	content := `{
+		"openapi": "3.0.0",
+		"paths": {
+			"/users": {
+				"get": {
+					"summary": "List users",
+					"description": "Get all users"
+				},
+				"post": {
+					"summary": "Create user"
+				}
+			},
+			"/users/{id}": {
+				"delete": {
+					"description": "Delete a user"
+				}
+			}
+		}
+	}`
+
+	spec, err := parseOpenAPI([]byte(content))
+	if err != nil {
+		t.Fatalf("parseOpenAPI failed: %v", err)
+	}
+
+	if spec.Format != "openapi" {
+		t.Errorf("expected format 'openapi', got %q", spec.Format)
+	}
+	if spec.Version != "3.0.0" {
+		t.Errorf("expected version '3.0.0', got %q", spec.Version)
+	}
+	if len(spec.Endpoints) != 3 {
+		t.Fatalf("expected 3 endpoints, got %d", len(spec.Endpoints))
+	}
+}
+
+func TestParseOpenAPIYAML(t *testing.T) {
+	content := `
+openapi: "3.1.0"
+paths:
+  /items:
+    get:
+      summary: List items
+`
+	spec, err := parseOpenAPI([]byte(content))
+	if err != nil {
+		t.Fatalf("parseOpenAPI YAML failed: %v", err)
+	}
+
+	if spec.Version != "3.1.0" {
+		t.Errorf("expected version '3.1.0', got %q", spec.Version)
+	}
+	if len(spec.Endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(spec.Endpoints))
+	}
+}
+
+func TestParsePostman(t *testing.T) {
+	collection := map[string]any{
+		"info": map[string]any{
+			"name":        "Test API",
+			"_postman_id": "abc-123",
+			"schema":      "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		},
+		"item": []any{
+			map[string]any{
+				"name": "Get Users",
+				"request": map[string]any{
+					"method": "GET",
+					"url":    "https://api.example.com/users",
+					"header": []any{},
+				},
+			},
+			map[string]any{
+				"name": "Create User",
+				"request": map[string]any{
+					"method": "POST",
+					"url":    "https://api.example.com/users",
+					"header": []any{
+						map[string]any{"key": "Authorization", "value": "Bearer token123"},
+					},
+					"body": map[string]any{
+						"mode": "raw",
+						"raw":  `{"name": "John"}`,
+					},
+				},
+			},
+		},
+	}
+
+	content, _ := json.Marshal(collection)
+	spec, err := parsePostman(content)
+	if err != nil {
+		t.Fatalf("parsePostman failed: %v", err)
+	}
+
+	if spec.Format != "postman" {
+		t.Errorf("expected format 'postman', got %q", spec.Format)
+	}
+	if spec.Version != "2.1" {
+		t.Errorf("expected version '2.1', got %q", spec.Version)
+	}
+	if len(spec.Endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(spec.Endpoints))
+	}
+
+	// Check auth detection
+	if spec.Endpoints[1].RequiresAuth != true {
+		t.Error("expected endpoint with Authorization header to require auth")
+	}
+	if spec.Endpoints[1].AuthType != "bearer" {
+		t.Errorf("expected auth type 'bearer', got %q", spec.Endpoints[1].AuthType)
+	}
+
+	// Check request body
+	if spec.Endpoints[1].RequestBody != `{"name": "John"}` {
+		t.Errorf("unexpected request body: %q", spec.Endpoints[1].RequestBody)
+	}
+}
+
+func TestParsePostmanNestedFolders(t *testing.T) {
+	collection := map[string]any{
+		"info": map[string]any{
+			"name":   "Nested API",
+			"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
+		},
+		"item": []any{
+			map[string]any{
+				"name": "Users Folder",
+				"item": []any{
+					map[string]any{
+						"name": "Get User",
+						"request": map[string]any{
+							"method": "GET",
+							"url":    "https://api.example.com/users/1",
+							"header": []any{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	content, _ := json.Marshal(collection)
+	spec, err := parsePostman(content)
+	if err != nil {
+		t.Fatalf("parsePostman failed: %v", err)
+	}
+
+	if len(spec.Endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint from nested folder, got %d", len(spec.Endpoints))
+	}
+	if spec.Endpoints[0].Path != "/users/1" {
+		t.Errorf("expected path '/users/1', got %q", spec.Endpoints[0].Path)
+	}
+}
+
+func TestExtractPostmanURL(t *testing.T) {
+	// String URL
+	got := extractPostmanURL("https://api.example.com/users")
+	if got != "/users" {
+		t.Errorf("string URL: expected '/users', got %q", got)
+	}
+
+	// Object URL with raw
+	got = extractPostmanURL(map[string]any{
+		"raw": "https://api.example.com/items",
+	})
+	if got != "/items" {
+		t.Errorf("object URL with raw: expected '/items', got %q", got)
+	}
+
+	// Object URL with path array
+	got = extractPostmanURL(map[string]any{
+		"path": []any{"api", "v1", "users"},
+	})
+	if got != "/api/v1/users" {
+		t.Errorf("object URL with path array: expected '/api/v1/users', got %q", got)
+	}
+
+	// Nil/unknown type
+	got = extractPostmanURL(42)
+	if got != "/" {
+		t.Errorf("unknown type: expected '/', got %q", got)
+	}
+}
+
+func TestParseGraphQL(t *testing.T) {
+	content := `
+type Query {
+  users: [User]
+  user(id: ID!): User
+}
+
+type Mutation {
+  createUser(name: String!, email: String!): User
+  deleteUser(id: ID!): Boolean
+}
+
+type User {
+  id: ID
+  name: String
+  email: String
+}
+`
+
+	spec, err := parseGraphQL(content)
+	if err != nil {
+		t.Fatalf("parseGraphQL failed: %v", err)
+	}
+
+	if spec.Format != "graphql" {
+		t.Errorf("expected format 'graphql', got %q", spec.Format)
+	}
+
+	if len(spec.Endpoints) != 4 {
+		t.Fatalf("expected 4 endpoints, got %d", len(spec.Endpoints))
+	}
+
+	// Queries should be GET
+	queryCount := 0
+	mutationCount := 0
+	for _, ep := range spec.Endpoints {
+		if ep.Method == "GET" {
+			queryCount++
+		}
+		if ep.Method == "POST" {
+			mutationCount++
+		}
+	}
+	if queryCount != 2 {
+		t.Errorf("expected 2 GET (query) endpoints, got %d", queryCount)
+	}
+	if mutationCount != 2 {
+		t.Errorf("expected 2 POST (mutation) endpoints, got %d", mutationCount)
+	}
+}
+
+func TestParseGraphQLField(t *testing.T) {
+	// Simple field
+	ep := parseGraphQLField("users: [User]", "Query")
+	if ep == nil {
+		t.Fatal("expected non-nil endpoint")
+	}
+	if ep.Method != "GET" {
+		t.Errorf("expected GET for Query, got %q", ep.Method)
+	}
+	if ep.Path != "/graphql/users" {
+		t.Errorf("expected path '/graphql/users', got %q", ep.Path)
+	}
+
+	// Field with args
+	ep = parseGraphQLField("createUser(name: String!, email: String): User", "Mutation")
+	if ep == nil {
+		t.Fatal("expected non-nil endpoint")
+	}
+	if ep.Method != "POST" {
+		t.Errorf("expected POST for Mutation, got %q", ep.Method)
+	}
+	if len(ep.Parameters) != 2 {
+		t.Fatalf("expected 2 parameters, got %d", len(ep.Parameters))
+	}
+	if !ep.Parameters[0].Required {
+		t.Error("expected name parameter to be required (has !)")
+	}
+	if ep.Parameters[1].Required {
+		t.Error("expected email parameter to not be required")
+	}
+
+	// Field with comment
+	ep = parseGraphQLField("users: [User] # Get all users", "Query")
+	if ep == nil {
+		t.Fatal("expected non-nil endpoint")
+	}
+	if ep.Description != "Get all users" {
+		t.Errorf("expected description 'Get all users', got %q", ep.Description)
+	}
+
+	// Empty field
+	ep = parseGraphQLField(": String", "Query")
+	if ep != nil {
+		t.Error("expected nil for field with no name")
+	}
+}

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -1,0 +1,62 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/Octrafic/octrafic-cli/internal/llm/common"
+)
+
+func TestEnsureV1Suffix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http://localhost:11434", "http://localhost:11434/v1"},
+		{"http://localhost:11434/", "http://localhost:11434/v1"},
+		{"http://localhost:11434/v1", "http://localhost:11434/v1"},
+		{"http://localhost:11434/v1/", "http://localhost:11434/v1"},
+		{"http://example.com/api", "http://example.com/api/v1"},
+	}
+
+	for _, tt := range tests {
+		got := ensureV1Suffix(tt.input)
+		if got != tt.expected {
+			t.Errorf("ensureV1Suffix(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestCreateProviderUnsupported(t *testing.T) {
+	_, err := CreateProvider(common.ProviderConfig{Provider: "unsupported"})
+	if err == nil {
+		t.Error("expected error for unsupported provider")
+	}
+}
+
+func TestCreateProviderOllamaDefaultURL(t *testing.T) {
+	provider, err := CreateProvider(common.ProviderConfig{
+		Provider: "ollama",
+		APIKey:   "dummy",
+		Model:    "llama3",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestCreateProviderLlamacppDefaultURL(t *testing.T) {
+	provider, err := CreateProvider(common.ProviderConfig{
+		Provider: "llamacpp",
+		APIKey:   "dummy",
+		Model:    "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}


### PR DESCRIPTION
## Summary
- Add ~29 unit tests for previously untested packages: parser, config, LLM factory, converter
- Fix GraphQL parser bug where `braceDepth` was reset to 0 on type declaration lines, causing fields to never be parsed

## Packages covered
- **parser**: markdown, OpenAPI (JSON/YAML), Postman (flat + nested), GraphQL, URL extraction, helper functions
- **config**: `ShouldCheckForUpdate`, `IsLocalProvider`, `GetEnvVarName`
- **llm/factory**: `ensureV1Suffix`, provider creation (ollama, llamacpp, unsupported)
- **converter**: `extractJSON` with markdown code blocks, plain JSON, nested, edge cases

## Test plan
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean