### PR TITLE
chore: update Go version to 1.26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Run tests
         run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.8.0
+          version: v2.9.0
 
       - name: Run tests
         run: go test -v ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for your interest in contributing!
 
 ## Development Setup
 
-**Prerequisites:** Go 1.25+
+**Prerequisites:** Go 1.26+
 
 ```bash
 # Clone and build

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,7 +62,7 @@ paru -S octrafic-bin
 
 ## Build from Source
 
-Requires Go 1.25+
+Requires Go 1.26+
 
 ```bash
 git clone https://github.com/Octrafic/octrafic-cli.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Octrafic/octrafic-cli
 
-go 1.25.4
+go 1.26
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.17.0
@@ -12,6 +12,7 @@ require (
 	github.com/muesli/reflow v0.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/tidwall/gjson v1.18.0
+	github.com/yuin/goldmark v1.7.16
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -45,7 +46,6 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/yuin/goldmark v1.7.16 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.27.0 // indirect


### PR DESCRIPTION
## Changes
- Update `go.mod` to require Go 1.26
- Update GitHub Actions workflows (test.yml, release.yml) to use Go 1.26
- Update documentation (CONTRIBUTING.md, INSTALL.md) to require Go 1.26

## Testing
- ✅ Tested build successfully with Go 1.26
- ✅ Binary runs correctly

## Notes
Uses `GOTOOLCHAIN=auto` to automatically download Go 1.26 if needed.