### PR TITLE
Support exporting unexecuted test plans

### DIFF
--- a/internal/agents/chat.go
+++ b/internal/agents/chat.go
@@ -155,7 +155,7 @@ func getMainAgentTools() []common.Tool {
 		},
 		{
 			Name:        "ExportTests",
-			Description: "Export executed API tests to files in the specified formats. Call this ONLY when the user explicitly requests to save/export tests. Do NOT call this automatically after test execution. Can export to multiple formats at once.",
+			Description: "Export API tests to files in the specified formats. Can export either executed tests or generated test plans (even if they haven't been executed yet). Call this ONLY when the user explicitly requests to save/export. Can export to multiple formats at once.",
 			InputSchema: map[string]any{
 				"type":                 "object",
 				"additionalProperties": false,

--- a/internal/cli/handlers.go
+++ b/internal/cli/handlers.go
@@ -786,13 +786,20 @@ func (m *TestUIModel) handleExportTests(toolCall agent.ToolCall) tea.Msg {
 		tests = make([]exporter.TestData, 0, len(m.tests))
 		for _, test := range m.tests {
 			requiresAuth := false
+			var headers map[string]string
+			var body interface{}
+
 			if test.BackendTest != nil {
 				requiresAuth = test.BackendTest.RequiresAuth
+				headers = test.BackendTest.Headers
+				body = test.BackendTest.Body
 			}
 			testData := exporter.TestData{
 				Method:       test.Method,
 				Endpoint:     test.Endpoint,
 				RequiresAuth: requiresAuth,
+				Headers:      headers,
+				Body:         body,
 			}
 			tests = append(tests, testData)
 		}

--- a/internal/cli/update_tests.go
+++ b/internal/cli/update_tests.go
@@ -12,7 +12,18 @@ import (
 // handleGenerateTestPlanResult processes the generated test plan from the agent.
 func handleGenerateTestPlanResult(m *TestUIModel, msg generateTestPlanResultMsg) (tea.Model, tea.Cmd) {
 	testCases := make([]map[string]any, 0, len(msg.backendTests))
-	for _, bt := range msg.backendTests {
+	m.tests = make([]Test, 0, len(msg.backendTests))
+	for i, bt := range msg.backendTests {
+		m.tests = append(m.tests, Test{
+			ID:          i + 1,
+			Method:      bt.TestCase.Method,
+			Endpoint:    bt.TestCase.Endpoint,
+			Description: fmt.Sprintf("%s %s", bt.TestCase.Method, bt.TestCase.Endpoint),
+			Status:      "pending",
+			Selected:    true,
+			BackendTest: &bt.TestCase,
+		})
+
 		testCases = append(testCases, map[string]any{
 			"method":        bt.TestCase.Method,
 			"endpoint":      bt.TestCase.Endpoint,


### PR DESCRIPTION
Allows exporting generated API tests (e.g. to Postman or Pytest) directly without needing to execute them first.