### PR TITLE
chore: add local CI script and fix staticcheck warnings

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+export GOTOOLCHAIN=auto
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}Starting local CI checks...${NC}\n"
+
+if ! command -v golangci-lint &> /dev/null; then
+    echo -e "${YELLOW}golangci-lint not found. Installing...${NC}"
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+    
+    export PATH=$PATH:$(go env GOPATH)/bin
+fi
+
+echo -e "${YELLOW}Running golangci-lint...${NC}"
+golangci-lint run
+echo -e "${GREEN}✓ Linter passed${NC}\n"
+
+echo -e "${YELLOW}Running unit tests...${NC}"
+go test -v ./...
+echo -e "${GREEN}✓ Tests passed${NC}\n"
+
+echo -e "${YELLOW}Verifying build...${NC}"
+GOTOOLCHAIN=auto go build -v ./cmd/octrafic
+rm -f ./octrafic
+echo -e "${GREEN}✓ Build verified${NC}\n"
+
+echo -e "${GREEN}All checks passed! You are ready to commit and push.${NC}"

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -285,10 +285,10 @@ func (m *ChatModel) listEndpoints() {
 	endpointList.WriteString("Available endpoints:")
 
 	for key, info := range m.analysis.EndpointInfo {
-		endpointList.WriteString(fmt.Sprintf("\n  %s\n", key))
-		endpointList.WriteString(fmt.Sprintf("    Purpose: %s\n", info.Purpose))
+		fmt.Fprintf(&endpointList, "\n  %s\n", key)
+		fmt.Fprintf(&endpointList, "    Purpose: %s\n", info.Purpose)
 		if len(info.TestScenarios) > 0 {
-			endpointList.WriteString(fmt.Sprintf("    Test scenarios: %d\n", len(info.TestScenarios)))
+			fmt.Fprintf(&endpointList, "    Test scenarios: %d\n", len(info.TestScenarios))
 		}
 	}
 
@@ -306,7 +306,7 @@ func (m *ChatModel) showInsights() {
 	insightsList.WriteString("AI Insights:")
 
 	for i, insight := range m.analysis.Insights {
-		insightsList.WriteString(fmt.Sprintf("\n  %d. %s", i+1, insight))
+		fmt.Fprintf(&insightsList, "\n  %d. %s", i+1, insight)
 	}
 
 	m.addSystemMessage(insightsList.String())

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -390,7 +390,7 @@ func renderTestPlanWithCheckboxes(m *TestUIModel) string {
 		endpoint := lipgloss.NewStyle().Foreground(Theme.Text).Render(test.Endpoint)
 		description := lipgloss.NewStyle().Foreground(Theme.TextMuted).Render(test.Description)
 
-		s.WriteString(fmt.Sprintf("%s %s %s %s → %s\n", indicator, checkbox, method, endpoint, description))
+		fmt.Fprintf(&s, "%s %s %s %s → %s\n", indicator, checkbox, method, endpoint, description)
 	}
 
 	// Help text

--- a/internal/exporter/curl.go
+++ b/internal/exporter/curl.go
@@ -16,15 +16,15 @@ func (e *CurlExporter) Export(req ExportRequest) error {
 	var script strings.Builder
 
 	script.WriteString("#!/bin/bash\n\n")
-	script.WriteString(fmt.Sprintf("# Generated curl commands for %s\n", req.BaseURL))
-	script.WriteString(fmt.Sprintf("BASE_URL=\"%s\"\n\n", req.BaseURL))
+	fmt.Fprintf(&script, "# Generated curl commands for %s\n", req.BaseURL)
+	fmt.Fprintf(&script, "BASE_URL=\"%s\"\n\n", req.BaseURL)
 
 	for i, test := range req.Tests {
 		if i > 0 {
 			script.WriteString("\n")
 		}
 
-		script.WriteString(fmt.Sprintf("# Test %d: %s %s\n", i+1, test.Method, test.Endpoint))
+		fmt.Fprintf(&script, "# Test %d: %s %s\n", i+1, test.Method, test.Endpoint)
 		script.WriteString(e.buildCurlCommand(test, req))
 		script.WriteString("\n")
 	}


### PR DESCRIPTION
Sets up a `check.sh` script to run the local CI validations and updates several internal files to adhere to new `golangci-lint@v2` rules (fixing QF1012 warnings).