### PR TITLE
add alt screen to interactive TUI

### DIFF
--- a/internal/cli/interactive.go
+++ b/internal/cli/interactive.go
@@ -14,7 +14,7 @@ import (
 func Start(baseURL string, specPath string, analysis *analyzer.Analysis, authProvider auth.AuthProvider, version string, yoloMode bool) {
 	model := NewTestUIModel(baseURL, specPath, analysis, authProvider, version, yoloMode, false)
 
-	p := tea.NewProgram(model, tea.WithMouseCellMotion())
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
 		logger.Error("Error running interactive mode", logger.Err(err))
 		os.Exit(1)
@@ -37,7 +37,7 @@ func StartWithProject(baseURL string, analysis *analyzer.Analysis, project *stor
 		// Conversation will be created on first user message (to get title from first prompt)
 	}
 
-	p := tea.NewProgram(model, tea.WithMouseCellMotion())
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
 		logger.Error("Error running interactive mode", logger.Err(err))
 		os.Exit(1)
@@ -60,7 +60,7 @@ func StartWithConversation(baseURL string, analysis *analyzer.Analysis, project 
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(model, tea.WithMouseCellMotion())
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
 		logger.Error("Error running interactive mode", logger.Err(err))
 		os.Exit(1)


### PR DESCRIPTION
Adds `tea.WithAltScreen()` to all three interactive TUI modes (`Start`, `StartWithProject`, `StartWithConversation`). Headless mode unchanged.