### PR TITLE
feat: add wait tool for agent rate limit handling

### DIFF
--- a/internal/agents/chat.go
+++ b/internal/agents/chat.go
@@ -184,6 +184,27 @@ func getMainAgentTools() []common.Tool {
 				"required": []string{"exports"},
 			},
 		},
+		{
+			Name:        "wait",
+			Description: "Wait for a specified number of seconds before proceeding. Use this when you receive a 429 rate limit response or a Retry-After header to pause before retrying.",
+			InputSchema: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]any{
+					"seconds": map[string]any{
+						"type":        "integer",
+						"description": "Number of seconds to wait (1-60)",
+						"minimum":     1,
+						"maximum":     60,
+					},
+					"reason": map[string]any{
+						"type":        "string",
+						"description": "Why you are waiting (e.g., 'Rate limit hit, Retry-After: 10')",
+					},
+				},
+				"required": []string{"seconds"},
+			},
+		},
 	}
 }
 
@@ -232,6 +253,13 @@ Parameters:
 
 ## ExecuteTestGroup
 Execute a group of tests against the API. Call AFTER GenerateTestPlan.
+Response includes: status_code, response_body, headers (check for Retry-After), duration_ms, passed.
+
+## wait
+Wait N seconds before proceeding. Use when:
+- You receive a 429 status code
+- Response headers contain Retry-After
+- You want to avoid hitting rate limits between test groups
 
 ## GenerateReport
 Generate PDF report from test results. Call AFTER tests are executed.
@@ -240,6 +268,7 @@ Generate PDF report from test results. Call AFTER tests are executed.
 - User mentions endpoint (e.g., "users", "auth") → fetch details, show info OR generate tests
 - User says "test X" → fetch details, generate & run tests
 - User says "list endpoints" → show list from available endpoints (no tool call)
+- After 429 response → call wait(seconds=N) where N comes from Retry-After header or default to 5
 - requires_auth=true → CLI adds auth header, requires_auth=false → no auth`, baseURL, endpointsInfo)
 }
 

--- a/internal/cli/handlers.go
+++ b/internal/cli/handlers.go
@@ -336,6 +336,7 @@ func (m *TestUIModel) executeTool(toolCall agent.ToolCall) tea.Cmd {
 					"status_code":     result.StatusCode,
 					"expected_status": expectedStatus,
 					"response_body":   result.ResponseBody,
+					"headers":         result.Headers,
 					"duration_ms":     result.Duration.Milliseconds(),
 					"passed":          passed,
 				},
@@ -420,6 +421,27 @@ func (m *TestUIModel) executeTool(toolCall agent.ToolCall) tea.Cmd {
 
 		if toolCall.Name == "ExportTests" {
 			return m.handleExportTests(toolCall)
+		}
+
+		if toolCall.Name == "wait" {
+			seconds := 5
+			if s, ok := toolCall.Arguments["seconds"].(float64); ok {
+				seconds = int(s)
+			} else if s, ok := toolCall.Arguments["seconds"].(int); ok {
+				seconds = s
+			}
+			if seconds < 1 {
+				seconds = 1
+			} else if seconds > 60 {
+				seconds = 60
+			}
+			time.Sleep(time.Duration(seconds) * time.Second)
+			return toolResultMsg{
+				toolID:   toolCall.ID,
+				toolName: toolCall.Name,
+				result:   map[string]any{"waited_seconds": seconds},
+				err:      nil,
+			}
 		}
 
 		return toolResultMsg{
@@ -729,6 +751,27 @@ func (m *TestUIModel) handleToolResult(toolName string, toolID string, result an
 			return m.sendChatMessage("")
 		}
 		return nil // No tool_use, so don't send response back
+	}
+
+	if toolName == "wait" {
+		if toolID != "" {
+			var resultMap map[string]any
+			if r, ok := result.(map[string]any); ok {
+				resultMap = r
+			}
+			chatMsg := agent.ChatMessage{
+				Role: "user",
+				FunctionResponse: &agent.FunctionResponseData{
+					ID:       toolID,
+					Name:     "wait",
+					Response: resultMap,
+				},
+			}
+			m.conversationHistory = append(m.conversationHistory, chatMsg)
+			m.saveChatMessageToConversation(chatMsg)
+			return m.sendChatMessage("")
+		}
+		return nil
 	}
 
 	return nil

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1332,6 +1332,27 @@ func handleProcessToolCalls(m *TestUIModel, _ processToolCallsMsg) (tea.Model, t
 			m.animationFrame = 0
 			m.spinner.Style = lipgloss.NewStyle().Foreground(Theme.Primary)
 			return m, tea.Batch(animationTick(), m.executeTool(toolCall))
+
+		case "wait":
+			m.currentTestToolID = toolCall.ID
+			m.currentTestToolName = "wait"
+
+			seconds := 5
+			if s, ok := toolCall.Arguments["seconds"].(float64); ok {
+				seconds = int(s)
+			} else if s, ok := toolCall.Arguments["seconds"].(int); ok {
+				seconds = s
+			}
+			label := fmt.Sprintf("%ds delay", seconds)
+			if reason, ok := toolCall.Arguments["reason"].(string); ok && reason != "" {
+				label = fmt.Sprintf("%ds delay — %s", seconds, reason)
+			}
+
+			showToolWidget(m, "Waiting", label)
+			m.agentState = StateUsingTool
+			m.animationFrame = 0
+			m.spinner.Style = lipgloss.NewStyle().Foreground(Theme.Warning)
+			return m, tea.Batch(animationTick(), m.executeTool(toolCall))
 		}
 
 		return m, func() tea.Msg { return processToolCallsMsg{} }

--- a/internal/core/tester/executor.go
+++ b/internal/core/tester/executor.go
@@ -14,6 +14,7 @@ import (
 type TestResult struct {
 	StatusCode   int
 	ResponseBody string
+	Headers      map[string]string
 	Duration     time.Duration
 	Error        error
 }
@@ -99,9 +100,15 @@ func (e *Executor) ExecuteTest(method, endpoint string, headers map[string]strin
 		}, err
 	}
 
+	responseHeaders := make(map[string]string)
+	for key := range resp.Header {
+		responseHeaders[key] = resp.Header.Get(key)
+	}
+
 	return &TestResult{
 		StatusCode:   resp.StatusCode,
 		ResponseBody: string(respBody),
+		Headers:      responseHeaders,
 		Duration:     duration,
 		Error:        nil,
 	}, nil


### PR DESCRIPTION
Adds a wait tool that allows the agent to pause execution when it encounters rate limiting (429 responses). The agent can call wait(seconds, reason) after receiving a 429 or Retry-After header.

Also passes response headers back to the agent in ExecuteTest results so it can read Retry-After and other rate limit headers.