### PR TITLE
feat: auto-approve test plans with only GET requests

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1414,7 +1414,15 @@ func handleShowTestSelection(m *TestUIModel, msg showTestSelectionMsg) (tea.Mode
 
 	m.pendingTestGroupToolCall = &msg.toolCall
 
-	if m.executionMode == ModeAutoExecute || m.isHeadless {
+	allGETs := len(m.tests) > 0
+	for _, test := range m.tests {
+		if test.Method != "GET" {
+			allGETs = false
+			break
+		}
+	}
+
+	if m.executionMode == ModeAutoExecute || m.isHeadless || allGETs {
 		m.addMessage("")
 
 		tests := make([]map[string]any, 0)


### PR DESCRIPTION
When the agent generates a test plan containing only GET requests, skip the confirmation checkbox UI and execute immediately. GET requests are read-only and safe by design.