### PR TITLE
fix: space key not toggling test plan checkboxes

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1016,6 +1016,9 @@ func handleTestPlanState(m *TestUIModel, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.selectedTestIndex++
 		}
 		return m, nil
+	case tea.KeySpace:
+		m.tests[m.selectedTestIndex].Selected = !m.tests[m.selectedTestIndex].Selected
+		return m, nil
 	case tea.KeyRunes:
 		if string(msg.Runes) == " " {
 			m.tests[m.selectedTestIndex].Selected = !m.tests[m.selectedTestIndex].Selected


### PR DESCRIPTION
Space was delivered as `tea.KeySpace` but the handler only checked `tea.KeyRunes`, so the toggle never fired. Added the missing `KeySpace` case.