### PR TITLE
feat: OpenAPI Auto-Scanner (OOPS Pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Open source CLI tool for automated API testing and reporting. Test your APIs by 
 ## Features
 
 - **Natural language testing** - describe what you want to test in plain English; the agent generates and executes the test plan
+- **OOPS Auto-Scanner** - scan your application source code to automatically generate OpenAPI 3.1 specifications
 - **Broad spec support** - OpenAPI 3.x, Swagger 2.0, Postman Collections, GraphQL, and Markdown docs
 - **Multiple auth methods** - Bearer token, API Key, Basic Auth, or none
 - **Export tests** - generate Postman collections, Python pytest files, or Bash curl scripts from any test session
@@ -48,6 +49,7 @@ octrafic
 
 **Guides**
 - [Chat Features](https://docs.octrafic.com/guides/chat-features)
+- [OpenAPI Scanner](https://docs.octrafic.com/guides/scanner)
 - [Project Management](https://docs.octrafic.com/guides/project-management)
 - [Providers](https://docs.octrafic.com/guides/providers)
 - [Authentication](https://docs.octrafic.com/guides/authentication)

--- a/cmd/octrafic/main.go
+++ b/cmd/octrafic/main.go
@@ -754,10 +754,21 @@ func loadAndStartConversation(project *storage.Project, conversation *storage.Co
 
 func main() {
 	_ = godotenv.Load()
-	if isFirstLaunch, err := internalConfig.IsFirstLaunch(); err == nil && isFirstLaunch {
-		completed := runOnboarding()
-		if !completed {
-			os.Exit(0)
+
+	skipOnboarding := false
+	if len(os.Args) > 1 {
+		cmd := os.Args[1]
+		if cmd == "test" || cmd == "scan" || cmd == "help" || cmd == "version" || cmd == "update" {
+			skipOnboarding = true
+		}
+	}
+
+	if !skipOnboarding {
+		if isFirstLaunch, err := internalConfig.IsFirstLaunch(); err == nil && isFirstLaunch {
+			completed := runOnboarding()
+			if !completed {
+				os.Exit(0)
+			}
 		}
 	}
 

--- a/cmd/octrafic/scan.go
+++ b/cmd/octrafic/scan.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Octrafic/octrafic-cli/internal/cli"
+	internalConfig "github.com/Octrafic/octrafic-cli/internal/config"
+	"github.com/Octrafic/octrafic-cli/internal/llm"
+	"github.com/Octrafic/octrafic-cli/internal/llm/common"
+	"github.com/Octrafic/octrafic-cli/internal/scanner"
+	"github.com/spf13/cobra"
+)
+
+var (
+	scanPath string
+	scanOut  string
+)
+
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Scan project directory and automatically generate OpenAPI spec.",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := internalConfig.Load()
+
+		provider := internalConfig.GetEnv("PROVIDER")
+		apiKey := internalConfig.GetEnv("API_KEY")
+		baseURL := internalConfig.GetEnv("BASE_URL")
+		modelName := internalConfig.GetEnv("MODEL")
+
+		if err == nil && cfg.Onboarded && (cfg.APIKey != "" || internalConfig.IsLocalProvider(cfg.Provider)) {
+			// Use config from file if available and no override
+			if provider == "" {
+				provider = cfg.Provider
+			}
+			if apiKey == "" {
+				apiKey = cfg.APIKey
+			}
+			if baseURL == "" {
+				baseURL = cfg.BaseURL
+			}
+			if modelName == "" {
+				modelName = cfg.Model
+			}
+		}
+
+		if provider == "" {
+			provider = "claude"
+		}
+		if apiKey == "" {
+			if provider == "openai" || provider == "openrouter" {
+				apiKey = os.Getenv("OPENAI_API_KEY")
+			} else {
+				apiKey = os.Getenv("ANTHROPIC_API_KEY")
+			}
+		}
+
+		if (apiKey == "" && !internalConfig.IsLocalProvider(provider)) || modelName == "" {
+			fmt.Fprintln(os.Stderr, "Error: missing LLM configuration.")
+			fmt.Fprintln(os.Stderr, "Please run 'octrafic' to complete interactive onboarding, or configure via environment variables (e.g., OCTRAFIC_PROVIDER, OCTRAFIC_API_KEY, OCTRAFIC_MODEL).")
+			fmt.Fprintln(os.Stderr, "Read more: https://docs.octrafic.com/guides/scanner.html")
+			os.Exit(1)
+		}
+
+		providerConfig := common.ProviderConfig{
+			Provider: provider,
+			APIKey:   apiKey,
+			BaseURL:  baseURL,
+			Model:    modelName,
+		}
+
+		llmProvider, err := llm.CreateProvider(providerConfig)
+		if err != nil {
+			fmt.Printf("Error creating LLM provider: %v\n", err)
+			os.Exit(1)
+		}
+
+		scannerInst, err := scanner.NewScanner(llmProvider, scanPath, scanOut)
+		if err != nil {
+			fmt.Printf("Error initializing scanner: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := cli.StartScannerUI(scannerInst); err != nil {
+			fmt.Printf("Error during scan: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func printScanHelp(cmd *cobra.Command) {
+	fmt.Printf("Scan project directory and automatically generate OpenAPI spec.\n\n")
+	fmt.Printf("Usage:\n  %s\n\n", cmd.UseLine())
+
+	fmt.Printf("Scan configuration:\n")
+	printFlag(cmd, "path", "p", "Target path to scan (default '.')")
+	printFlag(cmd, "out", "o", "Output file for the generated OpenAPI spec")
+
+	fmt.Printf("\nLearn more: https://github.com/Octrafic/octrafic-cli\n")
+}
+
+func init() {
+	scanCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		printScanHelp(cmd)
+	})
+	scanCmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		printScanHelp(cmd)
+		return nil
+	})
+
+	rootCmd.AddCommand(scanCmd)
+	scanCmd.Flags().StringVarP(&scanPath, "path", "p", ".", "Target path to scan")
+	scanCmd.Flags().StringVarP(&scanOut, "out", "o", "openapi.spec", "Output file for the generated OpenAPI spec")
+}

--- a/cmd/octrafic/test.go
+++ b/cmd/octrafic/test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Octrafic/octrafic-cli/internal/cli"
+	internalConfig "github.com/Octrafic/octrafic-cli/internal/config"
 	"github.com/Octrafic/octrafic-cli/internal/core/analyzer"
 	"github.com/Octrafic/octrafic-cli/internal/core/parser"
 	"github.com/Octrafic/octrafic-cli/internal/infra/storage"
@@ -26,6 +27,14 @@ var testCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if testPath == "" && testPrompt == "" {
 			fmt.Println("Error: You must provide a file path (--path) or a prompt (--prompt)")
+			os.Exit(1)
+		}
+
+		cfg, err := internalConfig.Load()
+		if err != nil || (!cfg.Onboarded && (internalConfig.GetEnv("API_KEY") == "" && !internalConfig.IsLocalProvider(internalConfig.GetEnv("PROVIDER"))) || internalConfig.GetEnv("MODEL") == "") {
+			fmt.Fprintln(os.Stderr, "Error: missing LLM configuration.")
+			fmt.Fprintln(os.Stderr, "Please run 'octrafic' to complete interactive onboarding, or configure via environment variables (e.g., OCTRAFIC_PROVIDER, OCTRAFIC_API_KEY, OCTRAFIC_MODEL).")
+			fmt.Fprintln(os.Stderr, "Read more: https://docs.octrafic.com/guides/headless.html")
 			os.Exit(1)
 		}
 

--- a/internal/cli/scan_ui.go
+++ b/internal/cli/scan_ui.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Octrafic/octrafic-cli/internal/scanner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ScanProgressMsg is sent by the scanner to update the UI
+type ScanProgressMsg struct {
+	Message string
+}
+
+// ScanDoneMsg is sent when scanning is complete
+type ScanDoneMsg struct {
+	Error error
+}
+
+// ScanUIModel represents the state of the scanning TUI
+type ScanUIModel struct {
+	scanner      *scanner.Scanner
+	status       string
+	spinnerFrame int
+	err          error
+	done         bool
+}
+
+// NewScanUIModel creates a new ScanUIModel
+func NewScanUIModel(s *scanner.Scanner) ScanUIModel {
+	return ScanUIModel{
+		scanner:      s,
+		status:       "Initializing scan...",
+		spinnerFrame: 0,
+		done:         false,
+	}
+}
+
+// Init starts the animation ticker
+func (m ScanUIModel) Init() tea.Cmd {
+	return animationTick()
+}
+
+// Update handles messages from the system and the background scanner
+func (m ScanUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" || msg.String() == "q" {
+			return m, tea.Quit
+		}
+	case animationTickMsg:
+		m.spinnerFrame++
+		if !m.done {
+			return m, animationTick()
+		}
+		return m, nil
+	case ScanProgressMsg:
+		msgStr := msg.Message
+		var formattedMsg string
+
+		if strings.HasPrefix(msgStr, "➔") {
+			// Main pipeline stages
+			bullet := lipgloss.NewStyle().Foreground(Theme.Primary).Render("➔")
+			text := lipgloss.NewStyle().Foreground(Theme.Primary).Bold(true).Render(strings.TrimSpace(strings.TrimPrefix(msgStr, "➔")))
+			formattedMsg = fmt.Sprintf("  %s %s\n", bullet, text)
+		} else if strings.HasPrefix(msgStr, "  ↳") {
+			// Sub-steps
+			bullet := lipgloss.NewStyle().Foreground(Theme.Cyan).Render("↳")
+			text := lipgloss.NewStyle().Foreground(Theme.TextSubtle).Render(strings.TrimSpace(strings.TrimPrefix(msgStr, "  ↳")))
+			formattedMsg = fmt.Sprintf("    %s %s\n", bullet, text)
+		} else if strings.HasPrefix(msgStr, "    ✓") {
+			// Success sub-hits
+			bullet := lipgloss.NewStyle().Foreground(Theme.Success).Render("✓")
+			text := lipgloss.NewStyle().Foreground(Theme.TextSubtle).Render(strings.TrimSpace(strings.TrimPrefix(msgStr, "    ✓")))
+			formattedMsg = fmt.Sprintf("      %s %s\n", bullet, text)
+		} else if strings.HasPrefix(msgStr, "✅") {
+			// Final success
+			formattedMsg = "\n" + lipgloss.NewStyle().Foreground(Theme.Success).Bold(true).Render("✅ "+strings.TrimSpace(strings.TrimPrefix(msgStr, "✅"))) + "\n"
+		} else {
+			formattedMsg = lipgloss.NewStyle().Foreground(Theme.Text).Render(msgStr) + "\n"
+		}
+
+		return m, tea.Printf("%s", strings.TrimRight(formattedMsg, "\n"))
+	case ScanDoneMsg:
+		m.done = true
+		if msg.Error != nil {
+			m.err = msg.Error
+			errorStyle := lipgloss.NewStyle().Foreground(Theme.Error).Bold(true)
+			return m, tea.Sequence(
+				tea.Printf("%s", errorStyle.Render("\n❌ Error during scan:\n")+lipgloss.NewStyle().Foreground(Theme.TextMuted).Render(m.err.Error())),
+				tea.Quit,
+			)
+		}
+
+		successStyle := lipgloss.NewStyle().Foreground(Theme.Success).Bold(true)
+		return m, tea.Sequence(
+			tea.Printf("%s", "\n"+successStyle.Render("✅ Scan complete!")+"\n"+lipgloss.NewStyle().Foreground(Theme.TextSubtle).Render("Generated specification saved output file.")),
+			tea.Quit,
+		)
+	}
+	return m, nil
+}
+
+// View renders the current state of the scanner UI
+func (m ScanUIModel) View() string {
+	return ""
+}
+
+// StartScannerUI runs the scanner wrapped in a BubbleTea program.
+func StartScannerUI(s *scanner.Scanner) error {
+	fmt.Println(lipgloss.NewStyle().Margin(1, 2).Render(RenderLogo()))
+	fmt.Println()
+
+	m := NewScanUIModel(s)
+	p := tea.NewProgram(m)
+
+	go func() {
+		err := s.RunScan(func(msg string) {
+			p.Send(ScanProgressMsg{Message: msg})
+		})
+		p.Send(ScanDoneMsg{Error: err})
+	}()
+
+	_, err := p.Run()
+	return err
+}

--- a/internal/scanner/detect_framework.go
+++ b/internal/scanner/detect_framework.go
@@ -1,0 +1,91 @@
+package scanner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Octrafic/octrafic-cli/internal/agents"
+)
+
+// ProjectFramework contains LLM-detected metadata about the project
+type ProjectFramework struct {
+	Language  string `json:"language"`
+	Framework string `json:"framework"`
+}
+
+// detectFramework finds dependency files and asks the LLM to identify the framework.
+func (s *Scanner) detectFramework(progressCallback func(string)) (*ProjectFramework, error) {
+	if progressCallback != nil {
+		progressCallback("➔ Analyzing project structure...")
+	}
+
+	// We only look at common root-level config files
+	configFiles := []string{
+		"go.mod", "package.json", "requirements.txt",
+		"pyproject.toml", "pom.xml", "build.gradle",
+		"composer.json", "Gemfile", "Cargo.toml",
+	}
+
+	var foundConfigs []string
+	var configContents strings.Builder
+
+	for _, file := range configFiles {
+		path := filepath.Join(s.dir, file)
+		content, err := os.ReadFile(path)
+		if err == nil {
+			foundConfigs = append(foundConfigs, file)
+			fmt.Fprintf(&configContents, "\n--- %s ---\n", file)
+			// Truncate to avoid massive lockfiles just in case, though these are usually small
+			if len(content) > 5000 {
+				configContents.Write(content[:5000])
+				configContents.WriteString("\n... (truncated)")
+			} else {
+				configContents.Write(content)
+			}
+		}
+	}
+
+	if len(foundConfigs) == 0 {
+		return &ProjectFramework{Language: "Unknown", Framework: "Unknown"}, nil
+	}
+
+	systemPrompt := `You are a framework analyzer.
+Based on the provided dependency files, identify the programming language and primary web/API framework used in the project.
+Output your response STRICTLY as a JSON object matching this schema:
+{
+  "language": "Go|Python|JavaScript|TypeScript|Java|PHP|Ruby|Rust|etc",
+  "framework": "Gin|Echo|Express|Django|FastAPI|Spring|etc"
+}
+Do not include markdown blocks, just the raw JSON string.`
+
+	messages := []agent.ChatMessage{
+		{
+			Role:    "user",
+			Content: fmt.Sprintf("Dependency files found:\n%s", configContents.String()),
+		},
+	}
+
+	response, err := s.baseAgent.Chat(systemPrompt, nil, messages, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect framework via LLM: %w", err)
+	}
+
+	var framework ProjectFramework
+	cleanJSON := strings.TrimPrefix(strings.TrimSpace(response.Message), "```json")
+	cleanJSON = strings.TrimPrefix(cleanJSON, "```")
+	cleanJSON = strings.TrimSuffix(cleanJSON, "```")
+
+	if err := json.Unmarshal([]byte(cleanJSON), &framework); err != nil {
+		// Fallback if LLM fails formatting
+		return &ProjectFramework{Language: "Unknown", Framework: "Unknown"}, nil
+	}
+
+	if progressCallback != nil {
+		progressCallback(fmt.Sprintf("  ↳ Detected: %s + %s", framework.Language, framework.Framework))
+	}
+
+	return &framework, nil
+}

--- a/internal/scanner/endpoint_extractor.go
+++ b/internal/scanner/endpoint_extractor.go
@@ -1,0 +1,145 @@
+package scanner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Octrafic/octrafic-cli/internal/agents"
+	"github.com/Octrafic/octrafic-cli/internal/infra/logger"
+)
+
+// EndpointDef represents a single scraped OpenAPI endpoint
+type EndpointDef struct {
+	Method       string         `json:"method"`
+	Path         string         `json:"path"`
+	Summary      string         `json:"summary"`
+	RequestBody  map[string]any `json:"requestBody,omitempty"`
+	ResponseBody map[string]any `json:"responseBody,omitempty"`
+}
+
+// FileExtractResult holds the endpoints found in one specific file
+type FileExtractResult struct {
+	File      string
+	Endpoints []EndpointDef
+	Error     error
+}
+
+// extractEndpoints spawns parallel LLM calls for each routing file to extract specific endpoints.
+func (s *Scanner) extractEndpoints(routingFiles []RouterFile, progressCallback func(string)) map[string][]EndpointDef {
+	if progressCallback != nil {
+		progressCallback("➔ Extracting endpoints...")
+	}
+
+	results := make(map[string][]EndpointDef)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	// Semaphore to limit massive parallel LLM calls (e.g. max 5 concurrent)
+	sem := make(chan struct{}, 5)
+
+	start := time.Now()
+
+	for i, routeFile := range routingFiles {
+		wg.Add(1)
+
+		go func(idx int, rf RouterFile) {
+			defer wg.Done()
+			sem <- struct{}{}        // Acquire
+			defer func() { <-sem }() // Release
+
+			if progressCallback != nil {
+				progressCallback(fmt.Sprintf("  ↳ Scanning %s...", rf.Path))
+			}
+
+			fileResults, err := s.extractFromFile(rf.Path)
+			if err != nil {
+				logger.Warn("Failed to extract endpoints from file", logger.String("file", rf.Path), logger.Err(err))
+				return
+			}
+
+			if len(fileResults) > 0 {
+				mu.Lock()
+				results[rf.Path] = fileResults
+				mu.Unlock()
+
+				if progressCallback != nil {
+					progressCallback(fmt.Sprintf("    ✓ Extracted %d endpoints", len(fileResults)))
+				}
+			}
+		}(i, routeFile)
+	}
+
+	wg.Wait()
+
+	if progressCallback != nil {
+		total := 0
+		for _, eps := range results {
+			total += len(eps)
+		}
+		progressCallback(fmt.Sprintf("    ✓ Found %d total endpoints in %s", total, time.Since(start).Round(time.Millisecond)))
+	}
+
+	return results
+}
+
+func (s *Scanner) extractFromFile(relPath string) ([]EndpointDef, error) {
+	absPath := filepath.Join(s.dir, relPath)
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("read file failed: %w", err)
+	}
+
+	systemPrompt := `You are an expert OpenAPI endpoint extractor.
+Analyze the provided source code file and extract ALL API endpoints defined inside it.
+Focus heavily on HTTP methods, route paths, request payloads (structs/classes parsed from body), and response structures.
+
+Output your response STRICTLY as a JSON array matching this schema exactly:
+[
+  {
+    "method": "GET",
+    "path": "/api/users/{id}",
+    "summary": "Fetches a user by ID",
+    "requestBody": null,
+    "responseBody": {
+		"id": "string",
+		"name": "string"
+	}
+  }
+]
+
+Do not include markdown blocks, explanations, or any other text. Output ONLY the raw JSON array.
+If no explicit endpoints are found in the file, output an empty array: []`
+
+	messages := []agent.ChatMessage{
+		{
+			Role:    "user",
+			Content: fmt.Sprintf("File Path: %s\n\n```\n%s\n```", relPath, string(content)),
+		},
+	}
+
+	response, err := s.baseAgent.Chat(systemPrompt, nil, messages, false)
+	if err != nil {
+		return nil, fmt.Errorf("agent chat failed: %w", err)
+	}
+
+	cleanJSON := strings.TrimPrefix(strings.TrimSpace(response.Message), "```json")
+	cleanJSON = strings.TrimPrefix(cleanJSON, "```")
+	cleanJSON = strings.TrimSuffix(cleanJSON, "```")
+	cleanJSON = strings.TrimSpace(cleanJSON)
+
+	if cleanJSON == "" || cleanJSON == "[]" {
+		return []EndpointDef{}, nil
+	}
+
+	var endpoints []EndpointDef
+	if err := json.Unmarshal([]byte(cleanJSON), &endpoints); err != nil {
+		return nil, fmt.Errorf("failed to parse extracted JSON: %w\nJSON was: %s", err, cleanJSON)
+	}
+
+	return endpoints, nil
+}

--- a/internal/scanner/ignore.go
+++ b/internal/scanner/ignore.go
@@ -1,0 +1,92 @@
+package scanner
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IgnoreMatcher holds gitignore patterns and evaluates if a file should be ignored
+type IgnoreMatcher struct {
+	patterns []string
+}
+
+// NewIgnoreMatcher creates a new matcher from a .gitignore file
+func NewIgnoreMatcher(dir string) (*IgnoreMatcher, error) {
+	matcher := &IgnoreMatcher{
+		patterns: []string{".git", ".git/", ".DS_Store", "node_modules/", "vendor/"}, // Default ignores
+	}
+
+	ignorePath := filepath.Join(dir, ".gitignore")
+	file, err := os.Open(ignorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return matcher, nil
+		}
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		matcher.patterns = append(matcher.patterns, line)
+	}
+
+	return matcher, scanner.Err()
+}
+
+// IsIgnored returns true if the given path matches any ignore patterns
+func (m *IgnoreMatcher) IsIgnored(path string, isDir bool) bool {
+	// Normalize path
+	path = filepath.ToSlash(path)
+
+	// Clean leading slash if any
+	path = strings.TrimPrefix(path, "/")
+
+	for _, pattern := range m.patterns {
+		pattern = filepath.ToSlash(pattern)
+		isDirPattern := strings.HasSuffix(pattern, "/")
+
+		cleanPattern := strings.TrimPrefix(pattern, "/")
+		cleanPattern = strings.TrimSuffix(cleanPattern, "/")
+
+		// Base name check
+		base := filepath.Base(path)
+
+		// If pattern ends with /, it only applies to directories
+		if isDirPattern && !isDir {
+			continue
+		}
+
+		// Direct match on base name
+		if base == cleanPattern {
+			return true
+		}
+
+		// Match using filepath.Match
+		matched, _ := filepath.Match(cleanPattern, base)
+		if matched {
+			return true
+		}
+
+		// Also check full path matching (e.g. for foo/bar style patterns)
+		if strings.Contains(cleanPattern, "/") {
+			matched, _ = filepath.Match(cleanPattern, path)
+			if matched {
+				return true
+			}
+			// Prefix match for directories
+			if strings.HasPrefix(path, cleanPattern+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/scanner/router_finder.go
+++ b/internal/scanner/router_finder.go
@@ -1,0 +1,123 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RouterFile contains the path to a routing file and some metadata about it
+type RouterFile struct {
+	Path        string
+	HitKeywords []string
+}
+
+// findRoutingFiles scans the project using filepath.WalkDir and identifies files that contain
+// routing definitions based on common framework keywords.
+func (s *Scanner) findRoutingFiles(framework *ProjectFramework, progressCallback func(string)) ([]RouterFile, error) {
+	if progressCallback != nil {
+		progressCallback("➔ Locating API routes...")
+	}
+
+	// Heuristics based on common frameworks
+	var keywords []string
+	switch strings.ToLower(framework.Language) {
+	case "go":
+		keywords = []string{
+			"http.HandleFunc", "mux.Handle", "r.GET", "r.POST",
+			"chi.NewRouter", "gin.Default", "fiber.New", "app.Get",
+			"r.HandleFunc", "HandleFunc(",
+		}
+	case "python":
+		keywords = []string{
+			"@app.route", "@router.get", "@api.get", "path(", "re_path(", "def get(",
+		}
+	case "javascript", "typescript":
+		keywords = []string{
+			"app.get(", "app.post(", "router.get(", "app.use('/", "@Controller", "@Get(",
+		}
+	case "java", "kotlin":
+		keywords = []string{
+			"@RestController", "@RequestMapping", "@GetMapping", "class ",
+		}
+	case "php":
+		keywords = []string{
+			"Route::get", "Route::post", "$app->get(",
+		}
+	default: // Catch-all sensible defaults
+		keywords = []string{
+			"router.", ".get(", ".post(", "@get", "Route::",
+		}
+	}
+
+	var routingFiles []RouterFile
+	err := filepath.WalkDir(s.dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, _ := filepath.Rel(s.dir, path)
+		if s.matcher != nil && s.matcher.IsIgnored(relPath, d.IsDir()) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		// Skip files that are huge, binary, or clearly not logic files
+		if isIgnorableExtension(path) {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil || info.Size() > 1024*1024*2 { // skip >2MB files for routing check
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		contentStr := string(content)
+		var hits []string
+
+		for _, kw := range keywords {
+			if strings.Contains(contentStr, kw) {
+				hits = append(hits, kw)
+			}
+		}
+
+		if len(hits) > 0 {
+			routingFiles = append(routingFiles, RouterFile{
+				Path:        relPath,
+				HitKeywords: hits,
+			})
+			if progressCallback != nil {
+				progressCallback(fmt.Sprintf("  ↳ Found routes in: %s", relPath))
+			}
+		}
+
+		return nil
+	})
+
+	return routingFiles, err
+}
+
+func isIgnorableExtension(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	ignorable := map[string]bool{
+		".md": true, ".txt": true, ".log": true, ".csv": true,
+		".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+		".mp4": true, ".mp3": true, ".wav": true, ".pdf": true,
+		".zip": true, ".tar": true, ".gz": true, ".exe": true,
+		".dll": true, ".so": true, ".dylib": true, ".bin": true,
+		".css": true, ".scss": true, ".html": true, ".svg": true,
+	}
+	return ignorable[ext]
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,0 +1,71 @@
+package scanner
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/Octrafic/octrafic-cli/internal/agents"
+	"github.com/Octrafic/octrafic-cli/internal/infra/logger"
+	"github.com/Octrafic/octrafic-cli/internal/llm/common"
+)
+
+// Scanner orchestrates the codebase scan
+type Scanner struct {
+	baseAgent *agent.BaseAgent
+	dir       string
+	outFile   string
+	matcher   *IgnoreMatcher
+}
+
+// NewScanner creates a new Scanner instance
+func NewScanner(provider common.Provider, dir, outFile string) (*Scanner, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path for dir: %w", err)
+	}
+
+	matcher, err := NewIgnoreMatcher(absDir)
+	if err != nil {
+		logger.Warn("Failed to load .gitignore", logger.Err(err))
+	}
+
+	return &Scanner{
+		baseAgent: agent.NewBaseAgent(provider),
+		dir:       absDir,
+		outFile:   outFile,
+		matcher:   matcher,
+	}, nil
+}
+
+// RunScan starts the OOPS Pipeline scanning process
+func (s *Scanner) RunScan(progressCallback func(string)) error {
+	// Stage 1: Framework Detection
+	framework, err := s.detectFramework(progressCallback)
+	if err != nil {
+		return fmt.Errorf("stage 1 (detectFramework) failed: %w", err)
+	}
+
+	// Stage 2: Routing Discovery
+	routingFiles, err := s.findRoutingFiles(framework, progressCallback)
+	if err != nil {
+		return fmt.Errorf("stage 2 (findRoutingFiles) failed: %w", err)
+	}
+
+	if len(routingFiles) == 0 {
+		return fmt.Errorf("no routing files found for framework %s", framework.Framework)
+	}
+
+	// Stage 3 & 4: Parallel Endpoint Extraction
+	endpoints := s.extractEndpoints(routingFiles, progressCallback)
+	if len(endpoints) == 0 {
+		return fmt.Errorf("no endpoints could be extracted from the identified routing files")
+	}
+
+	// Stage 5: Merge and YAML Generation
+	err = s.generateSpec(framework, endpoints, progressCallback)
+	if err != nil {
+		return fmt.Errorf("stage 5 (generateSpec) failed: %w", err)
+	}
+
+	return nil
+}

--- a/internal/scanner/spec_generator.go
+++ b/internal/scanner/spec_generator.go
@@ -1,0 +1,129 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// OasDocument represents a top-level OpenAPI 3.1 spec
+type OasDocument struct {
+	OpenAPI string                 `yaml:"openapi"`
+	Info    OasInfo                `yaml:"info"`
+	Paths   map[string]OasPathItem `yaml:"paths"`
+}
+
+type OasInfo struct {
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+	Version     string `yaml:"version"`
+}
+
+type OasPathItem map[string]OasOperation // "get", "post", etc. -> OasOperation
+
+type OasOperation struct {
+	Summary     string                 `yaml:"summary,omitempty"`
+	RequestBody *OasRequestBody        `yaml:"requestBody,omitempty"`
+	Responses   map[string]OasResponse `yaml:"responses"`
+}
+
+type OasRequestBody struct {
+	Content map[string]OasMediaType `yaml:"content"`
+}
+
+type OasResponse struct {
+	Description string                  `yaml:"description"`
+	Content     map[string]OasMediaType `yaml:"content,omitempty"`
+}
+
+type OasMediaType struct {
+	Schema map[string]any `yaml:"schema"`
+}
+
+// generateSpec merges all scraped snippets into a single OpenAPI 3.1.0 document
+func (s *Scanner) generateSpec(project *ProjectFramework, allEndpoints map[string][]EndpointDef, progressCallback func(string)) error {
+	if progressCallback != nil {
+		progressCallback("➔ Generating OpenAPI specification...")
+	}
+
+	doc := OasDocument{
+		OpenAPI: "3.1.0",
+		Info: OasInfo{
+			Title:       "Octrafic Auto-Generated API Spec",
+			Description: fmt.Sprintf("Automatically extracted via OOPS Architecture (%s / %s)", project.Language, project.Framework),
+			Version:     "1.0.0",
+		},
+		Paths: make(map[string]OasPathItem),
+	}
+
+	for _, fileEndpoints := range allEndpoints {
+		for _, ep := range fileEndpoints {
+			if ep.Path == "" || ep.Method == "" {
+				continue
+			}
+
+			methodLow := strings.ToLower(ep.Method)
+			if _, exists := doc.Paths[ep.Path]; !exists {
+				doc.Paths[ep.Path] = make(OasPathItem)
+			}
+
+			op := OasOperation{
+				Summary: ep.Summary,
+				Responses: map[string]OasResponse{
+					"200": {
+						Description: "Successful operation",
+					},
+				},
+			}
+
+			if len(ep.RequestBody) > 0 {
+				op.RequestBody = &OasRequestBody{
+					Content: map[string]OasMediaType{
+						"application/json": {
+							Schema: s.convertToJSONSchema(ep.RequestBody),
+						},
+					},
+				}
+			}
+
+			if len(ep.ResponseBody) > 0 {
+				op.Responses["200"] = OasResponse{
+					Description: "Successful operation",
+					Content: map[string]OasMediaType{
+						"application/json": {
+							Schema: s.convertToJSONSchema(ep.ResponseBody),
+						},
+					},
+				}
+			}
+
+			doc.Paths[ep.Path][methodLow] = op
+		}
+	}
+
+	yamlData, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal OpenAPI spec to YAML: %w", err)
+	}
+
+	err = os.WriteFile(s.outFile, yamlData, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write spec to file %s: %w", s.outFile, err)
+	}
+
+	if progressCallback != nil {
+		progressCallback(fmt.Sprintf("\n✅ Successfully generated specification and saved to %s", s.outFile))
+	}
+	return nil
+}
+
+// convertToJSONSchema takes a raw map (representing a struct/object definition)
+// and naively wraps it in a simplistic OpenAPI JSON schema wrapper.
+func (s *Scanner) convertToJSONSchema(obj map[string]any) map[string]any {
+	return map[string]any{
+		"type":       "object",
+		"properties": obj,
+	}
+}


### PR DESCRIPTION
## Description

Introduces the **OOPS Auto-Scanner** via the new `octrafic scan` command.

Allows users without an existing OpenAPI specification to automatically generate one directly from their codebase in an efficient, token-optimized manner.

### How it works:
1. **Framework Detection**: Scans root dependency files (`go.mod`, `package.json`, etc.) to heuristically detect the language and web framework.
2. **Routing Discovery**: Uses framework-specific targeting heuristics to find files likely containing application routes, avoiding massive directory dumps.
3. **Endpoint Extraction**: Processes routing logic in parallel via LLM, extracting methods, summaries, parameters, and request/response payloads while avoiding context length limits.
4. **Specification Generation**: Merges JSON outputs from the LLM into a final `openapi: 3.1.0` specification file (`api-spec.json` / `api-spec.yaml`).

### Fixes & Improvements
- Added strict headless-mode validation in `test.go` and `scan.go`. Headless commands will now securely abort with clear exit codes rather than hanging endlessly on the interactive Provider setup wizard if API keys are missing.
- Refactored BubbleTea TUI components for scanning feedback, giving clean, REPL-style output.