### PR TITLE
fix: Unify LLM config for headless mode and scan command

### DIFF
--- a/cmd/octrafic/scan.go
+++ b/cmd/octrafic/scan.go
@@ -21,46 +21,14 @@ var scanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "Scan project directory and automatically generate OpenAPI spec.",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := internalConfig.Load()
-
-		provider := internalConfig.GetEnv("PROVIDER")
-		apiKey := internalConfig.GetEnv("API_KEY")
-		baseURL := internalConfig.GetEnv("BASE_URL")
-		modelName := internalConfig.GetEnv("MODEL")
-
-		if err == nil && cfg.Onboarded && (cfg.APIKey != "" || internalConfig.IsLocalProvider(cfg.Provider)) {
-			// Use config from file if available and no override
-			if provider == "" {
-				provider = cfg.Provider
-			}
-			if apiKey == "" {
-				apiKey = cfg.APIKey
-			}
-			if baseURL == "" {
-				baseURL = cfg.BaseURL
-			}
-			if modelName == "" {
-				modelName = cfg.Model
-			}
-		}
-
-		if provider == "" {
-			provider = "claude"
-		}
-		if apiKey == "" {
-			if provider == "openai" || provider == "openrouter" {
-				apiKey = os.Getenv("OPENAI_API_KEY")
-			} else {
-				apiKey = os.Getenv("ANTHROPIC_API_KEY")
-			}
-		}
-
-		if (apiKey == "" && !internalConfig.IsLocalProvider(provider)) || modelName == "" {
+		if !internalConfig.HasValidLLMConfig() {
 			fmt.Fprintln(os.Stderr, "Error: missing LLM configuration.")
 			fmt.Fprintln(os.Stderr, "Please run 'octrafic' to complete interactive onboarding, or configure via environment variables (e.g., OCTRAFIC_PROVIDER, OCTRAFIC_API_KEY, OCTRAFIC_MODEL).")
 			fmt.Fprintln(os.Stderr, "Read more: https://docs.octrafic.com/guides/scanner.html")
 			os.Exit(1)
 		}
+
+		provider, apiKey, baseURL, modelName := internalConfig.GetActiveLLMConfig()
 
 		providerConfig := common.ProviderConfig{
 			Provider: provider,

--- a/cmd/octrafic/test.go
+++ b/cmd/octrafic/test.go
@@ -30,8 +30,7 @@ var testCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cfg, err := internalConfig.Load()
-		if err != nil || (!cfg.Onboarded && (internalConfig.GetEnv("API_KEY") == "" && !internalConfig.IsLocalProvider(internalConfig.GetEnv("PROVIDER"))) || internalConfig.GetEnv("MODEL") == "") {
+		if !internalConfig.HasValidLLMConfig() {
 			fmt.Fprintln(os.Stderr, "Error: missing LLM configuration.")
 			fmt.Fprintln(os.Stderr, "Please run 'octrafic' to complete interactive onboarding, or configure via environment variables (e.g., OCTRAFIC_PROVIDER, OCTRAFIC_API_KEY, OCTRAFIC_MODEL).")
 			fmt.Fprintln(os.Stderr, "Read more: https://docs.octrafic.com/guides/headless.html")

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Octrafic/octrafic-cli/internal/infra/logger"
 	"github.com/Octrafic/octrafic-cli/internal/llm"
 	"github.com/Octrafic/octrafic-cli/internal/llm/common"
-	"os"
 	"strings"
 )
 
@@ -60,53 +59,21 @@ func extractJSONFromMarkdown(response string) string {
 }
 
 func NewAgent(baseURL string) (*Agent, error) {
-	// Try loading config from file first (onboarding users)
-	cfg, err := config.Load()
-	if err == nil && cfg.Onboarded && (cfg.APIKey != "" || config.IsLocalProvider(cfg.Provider)) {
-		// Use config from file
-		logger.Info("Using LLM config from onboarding",
-			logger.String("provider", cfg.Provider),
-			logger.String("model", cfg.Model))
-
-		providerConfig := common.ProviderConfig{
-			Provider: cfg.Provider,
-			APIKey:   cfg.APIKey,
-			BaseURL:  cfg.BaseURL,
-			Model:    cfg.Model,
-		}
-
-		llmProvider, err := llm.CreateProvider(providerConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create provider: %w", err)
-		}
-
-		return &Agent{
-			baseAgent: NewBaseAgent(llmProvider),
-			baseURL:   baseURL,
-		}, nil
+	if !config.HasValidLLMConfig() {
+		return nil, fmt.Errorf("missing LLM configuration")
 	}
 
-	// Fallback to environment variables with OCTRAFIC_ prefix
-	provider := config.GetEnv("PROVIDER")
-	if provider == "" {
-		provider = "claude" // Default to Claude
-	}
+	provider, apiKey, configBaseURL, modelName := config.GetActiveLLMConfig()
 
-	apiKey := config.GetEnv("API_KEY")
-	if apiKey == "" {
-		// Legacy fallback for backwards compatibility
-		if provider == "openai" || provider == "openrouter" {
-			apiKey = os.Getenv("OPENAI_API_KEY")
-		} else {
-			apiKey = os.Getenv("ANTHROPIC_API_KEY")
-		}
-	}
+	logger.Info("Using LLM provider",
+		logger.String("provider", provider),
+		logger.String("model", modelName))
 
 	providerConfig := common.ProviderConfig{
 		Provider: provider,
 		APIKey:   apiKey,
-		BaseURL:  config.GetEnv("BASE_URL"),
-		Model:    config.GetEnv("MODEL"),
+		BaseURL:  configBaseURL,
+		Model:    modelName,
 	}
 
 	// Create provider
@@ -115,7 +82,6 @@ func NewAgent(baseURL string) (*Agent, error) {
 		return nil, fmt.Errorf("failed to create provider: %w", err)
 	}
 
-	logger.Info("Using LLM provider", logger.String("provider", provider))
 	return &Agent{
 		baseAgent: NewBaseAgent(llmProvider),
 		baseURL:   baseURL,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,3 +109,47 @@ func GetEnvVarName(key string) string {
 func GetEnv(key string) string {
 	return os.Getenv(GetEnvVarName(key))
 }
+
+// GetActiveLLMConfig resolves the effective LLM configuration by merging environment variables and saved config.
+func GetActiveLLMConfig() (provider, apiKey, baseURL, modelName string) {
+	cfg, err := Load()
+
+	provider = GetEnv("PROVIDER")
+	apiKey = GetEnv("API_KEY")
+	baseURL = GetEnv("BASE_URL")
+	modelName = GetEnv("MODEL")
+
+	if err == nil && cfg != nil && cfg.Onboarded && (cfg.APIKey != "" || IsLocalProvider(cfg.Provider)) {
+		if provider == "" {
+			provider = cfg.Provider
+		}
+		if apiKey == "" {
+			apiKey = cfg.APIKey
+		}
+		if baseURL == "" {
+			baseURL = cfg.BaseURL
+		}
+		if modelName == "" {
+			modelName = cfg.Model
+		}
+	}
+
+	if provider == "" {
+		provider = "claude"
+	}
+	if apiKey == "" {
+		if provider == "openai" || provider == "openrouter" {
+			apiKey = os.Getenv("OPENAI_API_KEY")
+		} else {
+			apiKey = os.Getenv("ANTHROPIC_API_KEY")
+		}
+	}
+
+	return provider, apiKey, baseURL, modelName
+}
+
+// HasValidLLMConfig checks whether there is a valid LLM configuration either in the environment or saved config.
+func HasValidLLMConfig() bool {
+	provider, apiKey, _, modelName := GetActiveLLMConfig()
+	return (apiKey != "" || IsLocalProvider(provider)) && modelName != ""
+}


### PR DESCRIPTION
Fixes an issue where `octrafic test` incorrectly reports missing LLM config even if the config exists in `config.json`.

Also unifies config parsing for `scan`, `test` and `internal/agents` components by exposing a shared helper `GetActiveLLMConfig()`.